### PR TITLE
Corrected path in MetaFields package.manifest

### DIFF
--- a/src/uSeoToolkit.Umbraco.MetaFields/App_Plugins/uSeoToolkit/MetaFields/package.manifest
+++ b/src/uSeoToolkit.Umbraco.MetaFields/App_Plugins/uSeoToolkit/MetaFields/package.manifest
@@ -4,7 +4,7 @@
     "~/App_Plugins/uSeoToolkit/MetaFields/Interface/ContentApps/DocumentSettings/Dialog/settingDialog.controller.js",
     "~/App_Plugins/uSeoToolkit/MetaFields/Interface/ContentApps/SeoSettings/seoSettings.controller.js",
     "~/App_Plugins/uSeoToolkit/MetaFields/Interface/Components/DynamicSelectBox/dynamicSelectBox.controller.js",
-    "~/App_Plugins/uSeoToolkit/MetaFields/Interface/Previewers/BaseTags/baseTagsPreviewer.controller.js",
+    "~/App_Plugins/uSeoToolkit/MetaFields/Interface/Previewers/BaseTags/baseTagsFieldPreviewer.controller.js",
     "~/App_Plugins/uSeoToolkit/MetaFields/Interface/SeoFieldEditors/FieldsEditor/fieldsEditor.controller.js",
     "~/App_Plugins/uSeoToolkit/MetaFields/Interface/SeoFieldEditors/PropertyEditor/propertyEditor.controller.js"
   ],


### PR DESCRIPTION
The `package.manifest` for MetaFields was trying to load the script "baseTagsPreviewer.controller.js", but the correct filename is "baseTagsFieldPreviewer.controller.js". This caused a 404 error in the backoffice.