### PR TITLE
Wired up main dashboard links

### DIFF
--- a/src/uSeoToolkit.Umbraco.Common.Core/Collections/ModuleCollection.cs
+++ b/src/uSeoToolkit.Umbraco.Common.Core/Collections/ModuleCollection.cs
@@ -12,10 +12,34 @@ namespace uSeoToolkit.Umbraco.Common.Core.Collections
         {
             _items = new List<SeoToolkitModule>
             {
-                new SeoToolkitModule{Title = "Meta Fields", Alias = "metaFields", Icon = "icon-thumbnail-list", Link = "https://github.com/patrickdemooij9/uSeoToolkit.Umbraco"},
-                new SeoToolkitModule{Title = "Script Manager", Alias = "scriptManager", Icon = "icon-script", Link = "https://github.com/patrickdemooij9/uSeoToolkit.Umbraco"},
-                new SeoToolkitModule{Title = "Sitemap", Alias = "sitemap", Icon = "icon-sitemap", Link = "https://github.com/patrickdemooij9/uSeoToolkit.Umbraco"},
-                new SeoToolkitModule{Title = "Robots.txt", Alias = "robotsTxt", Icon = "icon-cloud", Link = "https://github.com/patrickdemooij9/uSeoToolkit.Umbraco"}
+                new SeoToolkitModule
+                {
+                    Title = "Meta Fields",
+                    Alias = "metaFields",
+                    Icon = "icon-thumbnail-list",
+                    Link = "https://useotoolkit.gitbook.io/useotoolkit/getting-started/meta-fields"
+                },
+                new SeoToolkitModule
+                {
+                    Title = "Script Manager",
+                    Alias = "scriptManager",
+                    Icon = "icon-script",
+                    Link = "https://useotoolkit.gitbook.io/useotoolkit/getting-started/script-manager"
+                },
+                new SeoToolkitModule
+                {
+                    Title = "Sitemap",
+                    Alias = "sitemap",
+                    Icon = "icon-sitemap",
+                    Link = "https://useotoolkit.gitbook.io/useotoolkit/getting-started/sitemap"
+                },
+                new SeoToolkitModule
+                {
+                    Title = "Robots.txt",
+                    Alias = "robotsTxt",
+                    Icon = "icon-cloud",
+                    Link = "https://useotoolkit.gitbook.io/useotoolkit/getting-started/robots.txt"
+                }
             };
         }
 

--- a/src/uSeoToolkit.Umbraco.Common/App_Plugins/uSeoToolkit/Dashboards/welcomeDashboard.html
+++ b/src/uSeoToolkit.Umbraco.Common/App_Plugins/uSeoToolkit/Dashboards/welcomeDashboard.html
@@ -1,5 +1,5 @@
 ﻿<div class="welcomeDashboard" ng-controller="uSeoToolkit.uSeoToolkit.WelcomeDashboardController as vm">
-    
+
     <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
 
     <h1>Welcome!</h1>
@@ -8,7 +8,7 @@
         <p>Here you can see what modules are installed. Each functionality is shipped in its own package. So you can mix and match to your liking!</p>
     </div>
     <div class="modules">
-        <a ng-href="item.link" ng-repeat="item in vm.modules" class="module">
+        <a href="#" ng-href="{{item.link}}" ng-repeat="item in vm.modules" class="module" target="_blank">
             <div class="module-icon">
                 <umb-icon icon="{{item.icon}}"></umb-icon>
             </div>


### PR DESCRIPTION
This fixes issue #17.

I've updated and wired-up the module links on the main dashboard.

I've also added a `target="_blank"` so that they open in a new tab/window.
