### PR TITLE
Adds migrations to create user-group and add section to admin group

### DIFF
--- a/src/uSeoToolkit.Umbraco.Common.Core/Migrations/AddSeoToolkitSectionToAdminUserGroupMigration.cs
+++ b/src/uSeoToolkit.Umbraco.Common.Core/Migrations/AddSeoToolkitSectionToAdminUserGroupMigration.cs
@@ -1,0 +1,30 @@
+﻿using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Migrations;
+using uSeoToolkit.Umbraco.Common.Core.Sections;
+using UmbConstants = Umbraco.Cms.Core.Constants;
+
+namespace uSeoToolkit.Umbraco.Common.Core.Migrations
+{
+    public class AddSeoToolkitSectionToAdminUserGroupMigration : MigrationBase
+    {
+        private readonly IUserService _userService;
+
+        public AddSeoToolkitSectionToAdminUserGroupMigration(IMigrationContext context, IUserService userService)
+           : base(context)
+        {
+            _userService = userService;
+        }
+
+        protected override void Migrate()
+        {
+            var userGroup = _userService.GetUserGroupByAlias(UmbConstants.Security.AdminGroupAlias);
+
+            if (userGroup != null)
+            {
+                userGroup.AddAllowedSection(USeoToolkitSection.SectionAlias);
+
+                _userService.Save(userGroup);
+            }
+        }
+    }
+}

--- a/src/uSeoToolkit.Umbraco.Common.Core/Migrations/CreateSeoToolkitUserGroupMigration.cs
+++ b/src/uSeoToolkit.Umbraco.Common.Core/Migrations/CreateSeoToolkitUserGroupMigration.cs
@@ -1,0 +1,38 @@
+﻿using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Strings;
+using Umbraco.Cms.Infrastructure.Migrations;
+using uSeoToolkit.Umbraco.Common.Core.Sections;
+
+namespace uSeoToolkit.Umbraco.Common.Core.Migrations
+{
+    public class CreateSeoToolkitUserGroupMigration : MigrationBase
+    {
+        private readonly IShortStringHelper _shortStringHelper;
+        private readonly IUserService _userService;
+
+        public CreateSeoToolkitUserGroupMigration(
+            IMigrationContext context,
+            IShortStringHelper shortStringHelper,
+            IUserService userService)
+           : base(context)
+        {
+            _shortStringHelper = shortStringHelper;
+            _userService = userService;
+        }
+
+        protected override void Migrate()
+        {
+            var userGroup = new UserGroup(_shortStringHelper)
+            {
+                Alias = "uSeoToolkit",
+                Name = "SEO Toolkit",
+                Icon = "icon-globe-alt",
+            };
+
+            userGroup.AddAllowedSection(USeoToolkitSection.SectionAlias);
+
+            _userService.Save(userGroup);
+        }
+    }
+}

--- a/src/uSeoToolkit.Umbraco.Common.Core/Migrations/CreateSeoToolkitUserGroupMigration.cs
+++ b/src/uSeoToolkit.Umbraco.Common.Core/Migrations/CreateSeoToolkitUserGroupMigration.cs
@@ -8,6 +8,8 @@ namespace uSeoToolkit.Umbraco.Common.Core.Migrations
 {
     public class CreateSeoToolkitUserGroupMigration : MigrationBase
     {
+        private const string UserGroupAlias = "uSeoToolkit";
+
         private readonly IShortStringHelper _shortStringHelper;
         private readonly IUserService _userService;
 
@@ -23,9 +25,12 @@ namespace uSeoToolkit.Umbraco.Common.Core.Migrations
 
         protected override void Migrate()
         {
+            if (_userService.GetUserGroupByAlias(UserGroupAlias) != null)
+                return;
+
             var userGroup = new UserGroup(_shortStringHelper)
             {
-                Alias = "uSeoToolkit",
+                Alias = UserGroupAlias,
                 Name = "SEO Toolkit",
                 Icon = "icon-globe-alt",
             };

--- a/src/uSeoToolkit.Umbraco.Common.Core/Migrations/USeoToolkitMigrationPlan.cs
+++ b/src/uSeoToolkit.Umbraco.Common.Core/Migrations/USeoToolkitMigrationPlan.cs
@@ -11,6 +11,8 @@ namespace uSeoToolkit.Umbraco.Common.Core.Migrations
         protected override void DefinePlan()
         {
             To<SeoSettingsInitialMigration>("state-1");
+            To<AddSeoToolkitSectionToAdminUserGroupMigration>("state-2");
+            To<CreateSeoToolkitUserGroupMigration>("state-3");
         }
     }
 }


### PR DESCRIPTION
This implements a solution for issue #16.

I've added 2 migrations, one for adding the SEO section to the "admin" user-group, and the second to create a separate user-group (for granular SEO user access).

@patrickdemooij9 If you don't want the "admin" group to have the SEO section, I can either update the PR, or feel free to change the code as you want it.

