### PR TITLE
Removes 3-dot menu for tree items

### DIFF
--- a/src/uSeoToolkit.Umbraco.Core/Controllers/SeoToolkitLicenseTreeController.cs
+++ b/src/uSeoToolkit.Umbraco.Core/Controllers/SeoToolkitLicenseTreeController.cs
@@ -9,28 +9,35 @@ using Umbraco.Cms.Web.Common.Attributes;
 
 namespace uSeoToolkit.Umbraco.Core.Controllers
 {
-    [Tree("uSeoToolkit", "License", TreeTitle = "uSeoToolkit", TreeGroup = "uSeoToolkit", SortOrder = 20)]
+    [Tree("uSeoToolkit", "License", TreeTitle = "License", TreeGroup = "uSeoToolkit", SortOrder = 20)]
     [PluginController("uSeoToolkit")]
     public class SeoToolkitLicenseTreeController : TreeController
     {
-        public SeoToolkitLicenseTreeController(ILocalizedTextService localizedTextService, UmbracoApiControllerTypeCollection umbracoApiControllerTypeCollection, IEventAggregator eventAggregator) : base(localizedTextService, umbracoApiControllerTypeCollection, eventAggregator)
-        {
-        }
-
-        protected override ActionResult<TreeNodeCollection> GetTreeNodes(string id, FormCollection queryStrings)
-        {
-            return new TreeNodeCollection();
-        }
+        public SeoToolkitLicenseTreeController(
+            ILocalizedTextService localizedTextService,
+            UmbracoApiControllerTypeCollection umbracoApiControllerTypeCollection,
+            IEventAggregator eventAggregator)
+            : base(localizedTextService, umbracoApiControllerTypeCollection, eventAggregator)
+        { }
 
         protected override ActionResult<TreeNode> CreateRootNode(FormCollection queryStrings)
         {
-            var node = CreateTreeNode("license", "-1", queryStrings, "License", "icon-pushpin color-green", false,
-                $"{SectionAlias}/{TreeAlias}/licenseDashboard");
+            var root = base.CreateRootNode(queryStrings);
 
-            return node;
+            root.Value.Icon = "icon-pushpin color-green";
+            root.Value.HasChildren = false;
+            root.Value.RoutePath = $"{SectionAlias}/{TreeAlias}/licenseDashboard";
+            root.Value.MenuUrl = null;
+
+            return root.Value;
         }
 
         protected override ActionResult<MenuItemCollection> GetMenuForNode(string id, FormCollection queryStrings)
+        {
+            return null;
+        }
+
+        protected override ActionResult<TreeNodeCollection> GetTreeNodes(string id, FormCollection queryStrings)
         {
             return null;
         }

--- a/src/uSeoToolkit.Umbraco.RobotsTxt.Core/Controllers/RobotsTxtTreeController.cs
+++ b/src/uSeoToolkit.Umbraco.RobotsTxt.Core/Controllers/RobotsTxtTreeController.cs
@@ -1,39 +1,43 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using System;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Trees;
 using Umbraco.Cms.Web.BackOffice.Trees;
 using Umbraco.Cms.Web.Common.Attributes;
-using Umbraco.Cms.Web.Common.ModelBinders;
 
 namespace uSeoToolkit.Umbraco.RobotsTxt.Core.Controllers
 {
-    [Tree("uSeoToolkit", "RobotsTxt", TreeTitle = "uSeoToolkit", TreeGroup = "uSeoToolkit", SortOrder = 3)]
+    [Tree("uSeoToolkit", "RobotsTxt", TreeTitle = "Robots.txt", TreeGroup = "uSeoToolkit", SortOrder = 3)]
     [PluginController("uSeoToolkit")]
     public class RobotsTxtTreeController : TreeController
     {
-        public RobotsTxtTreeController(ILocalizedTextService localizedTextService, UmbracoApiControllerTypeCollection umbracoApiControllerTypeCollection, IEventAggregator eventAggregator,
-            IMenuItemCollectionFactory menuItemCollectionFactory) : base(localizedTextService, umbracoApiControllerTypeCollection, eventAggregator)
-        {
-        }
-
-        protected override ActionResult<TreeNodeCollection> GetTreeNodes(string id, FormCollection queryStrings)
-        {
-            return new TreeNodeCollection();
-        }
+        public RobotsTxtTreeController(
+            ILocalizedTextService localizedTextService,
+            UmbracoApiControllerTypeCollection umbracoApiControllerTypeCollection,
+            IEventAggregator eventAggregator)
+            : base(localizedTextService, umbracoApiControllerTypeCollection, eventAggregator)
+        { }
 
         protected override ActionResult<TreeNode> CreateRootNode(FormCollection queryStrings)
         {
-            var node = CreateTreeNode("robotsTxt", "-1", queryStrings, "Robots.txt", "icon-cloud", false,
-                $"{SectionAlias}/{TreeAlias}/detail");
+            var root = base.CreateRootNode(queryStrings);
 
-            return node;
+            root.Value.Icon = "icon-cloud";
+            root.Value.HasChildren = false;
+            root.Value.RoutePath = $"{SectionAlias}/{TreeAlias}/detail";
+            root.Value.MenuUrl = null;
+
+            return root.Value;
         }
 
         protected override ActionResult<MenuItemCollection> GetMenuForNode(string id, FormCollection queryStrings)
+        {
+            return null;
+        }
+
+        protected override ActionResult<TreeNodeCollection> GetTreeNodes(string id, FormCollection queryStrings)
         {
             return null;
         }

--- a/src/uSeoToolkit.Umbraco.ScriptManager.Core/Controllers/ScriptManagerTreeController.cs
+++ b/src/uSeoToolkit.Umbraco.ScriptManager.Core/Controllers/ScriptManagerTreeController.cs
@@ -1,47 +1,59 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Actions;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Trees;
 using Umbraco.Cms.Web.BackOffice.Trees;
 using Umbraco.Cms.Web.Common.Attributes;
+using UmbConstants = Umbraco.Cms.Core.Constants;
 
 namespace uSeoToolkit.Umbraco.ScriptManager.Core.Controllers
 {
-    [Tree("uSeoToolkit", "ScriptManager", TreeTitle = "uSeoToolkit", TreeGroup = "uSeoToolkit", SortOrder = 2)]
+    [Tree("uSeoToolkit", "ScriptManager", TreeTitle = "Script Manager", TreeGroup = "uSeoToolkit", SortOrder = 2)]
     [PluginController("uSeoToolkit")]
     public class ScriptManagerTreeController : TreeController
     {
         private readonly IMenuItemCollectionFactory _menuItemCollectionFactory;
 
-        public ScriptManagerTreeController(ILocalizedTextService localizedTextService,
+        public ScriptManagerTreeController(
+            ILocalizedTextService localizedTextService,
             UmbracoApiControllerTypeCollection umbracoApiControllerTypeCollection,
             IEventAggregator eventAggregator,
-            IMenuItemCollectionFactory menuItemCollectionFactory) : base(localizedTextService, umbracoApiControllerTypeCollection, eventAggregator)
+            IMenuItemCollectionFactory menuItemCollectionFactory)
+            : base(localizedTextService, umbracoApiControllerTypeCollection, eventAggregator)
         {
             _menuItemCollectionFactory = menuItemCollectionFactory;
         }
 
-        protected override ActionResult<TreeNodeCollection> GetTreeNodes(string id, FormCollection queryStrings)
-        {
-            return new TreeNodeCollection();
-        }
-
         protected override ActionResult<TreeNode> CreateRootNode(FormCollection queryStrings)
         {
-            var node = CreateTreeNode("siteManager", "-1", queryStrings, "Script Manager", "icon-script", false,
-                $"{SectionAlias}/{TreeAlias}/list");
+            var root = base.CreateRootNode(queryStrings);
 
-            return node;
+            root.Value.Icon = "icon-script";
+            root.Value.HasChildren = false;
+            root.Value.RoutePath = $"{SectionAlias}/{TreeAlias}/list";
+
+            return root.Value;
         }
 
         protected override ActionResult<MenuItemCollection> GetMenuForNode(string id, FormCollection queryStrings)
+        {
+            if (id == UmbConstants.System.RootString)
+            {
+                var menuItemCollection = _menuItemCollectionFactory.Create();
+
+                var item = menuItemCollection.Items.Add<ActionNew>(LocalizedTextService, opensDialog: true);
+                item.NavigateToRoute($"{SectionAlias}/{TreeAlias}/edit");
+
+                return menuItemCollection;
+            }
+
+            return null;
+        }
+
+        protected override ActionResult<TreeNodeCollection> GetTreeNodes(string id, FormCollection queryStrings)
         {
             return null;
         }

--- a/src/uSeoToolkit.Umbraco.SiteAudit.Core/Controllers/SiteAuditTreeController.cs
+++ b/src/uSeoToolkit.Umbraco.SiteAudit.Core/Controllers/SiteAuditTreeController.cs
@@ -8,46 +8,53 @@ using Umbraco.Cms.Core.Trees;
 using Umbraco.Cms.Web.BackOffice.Trees;
 using Umbraco.Cms.Web.Common.Attributes;
 using Umbraco.Extensions;
+using UmbConstants = Umbraco.Cms.Core.Constants;
 
 namespace uSeoToolkit.Umbraco.SiteAudit.Core.Controllers
 {
-    [Tree("uSeoToolkit", "SiteAudit", TreeTitle = "uSeoToolkit", TreeGroup = "uSeoToolkit", SortOrder = 1)]
+    [Tree("uSeoToolkit", "SiteAudit", TreeTitle = "Site Audits", TreeGroup = "uSeoToolkit", SortOrder = 1)]
     [PluginController("uSeoToolkitSiteAudit")]
     public class SeoToolkitTreeController : TreeController
     {
-        public IMenuItemCollectionFactory MenuItemCollectionFactory { get; }
+        private readonly IMenuItemCollectionFactory _menuItemCollectionFactory;
 
         public SeoToolkitTreeController(ILocalizedTextService localizedTextService,
             UmbracoApiControllerTypeCollection umbracoApiControllerTypeCollection,
             IEventAggregator eventAggregator,
-            IMenuItemCollectionFactory menuItemCollectionFactory) : base(localizedTextService, umbracoApiControllerTypeCollection, eventAggregator)
+            IMenuItemCollectionFactory menuItemCollectionFactory)
+            : base(localizedTextService, umbracoApiControllerTypeCollection, eventAggregator)
         {
-            MenuItemCollectionFactory = menuItemCollectionFactory;
-        }
-
-        protected override ActionResult<TreeNodeCollection> GetTreeNodes(string id, FormCollection queryStrings)
-        {
-            return new TreeNodeCollection();
+            _menuItemCollectionFactory = menuItemCollectionFactory;
         }
 
         protected override ActionResult<TreeNode> CreateRootNode(FormCollection queryStrings)
         {
-            var node = CreateTreeNode("siteAudit", "-1", queryStrings, "Site Audits", "icon-diagnostics", false,
-                $"{SectionAlias}/{TreeAlias}/list");
+            var root = base.CreateRootNode(queryStrings);
 
-            return node;
+            root.Value.Icon = "icon-diagnostics";
+            root.Value.HasChildren = false;
+            root.Value.RoutePath = $"{SectionAlias}/{TreeAlias}/list";
+
+            return root.Value;
         }
 
         protected override ActionResult<MenuItemCollection> GetMenuForNode(string id, FormCollection queryStrings)
         {
-            var menuItemCollection = MenuItemCollectionFactory.Create();
-            if (id == "siteAudit")
+            if (id == UmbConstants.System.RootString)
             {
+                var menuItemCollection = _menuItemCollectionFactory.Create();
                 var item = menuItemCollection.Items.Add<ActionNew>(LocalizedTextService, opensDialog: true);
-                item.NavigateToRoute($"{queryStrings.GetRequiredValue<string>("application")}/SiteAudit/create");
+                item.NavigateToRoute($"{queryStrings.GetRequiredValue<string>("application")}/{TreeAlias}/create");
+
+                return menuItemCollection;
             }
 
-            return menuItemCollection;
+            return null;
+        }
+
+        protected override ActionResult<TreeNodeCollection> GetTreeNodes(string id, FormCollection queryStrings)
+        {
+            return null;
         }
     }
 }


### PR DESCRIPTION
This fixes issue #19.

Also added the menu action for the Script Manager tree item, fixing issue #18.
