### PR TITLE
SEO naming alignment

### DIFF
--- a/src/uSeoToolkit.Umbraco.Common/App_Plugins/uSeoToolkit/ContentApps/DocumentType/seoSettings.controller.js
+++ b/src/uSeoToolkit.Umbraco.Common/App_Plugins/uSeoToolkit/ContentApps/DocumentType/seoSettings.controller.js
@@ -49,9 +49,9 @@
                     enabled: vm.model.enableSeoSettings
                 }).then(function (response) {
                     if (response.status !== 200) {
-                        notificationsService.error("Something went wrong while saving Seo Settings");
+                        notificationsService.error("Something went wrong while saving SEO settings");
                     } else {
-                        notificationsService.success("Seo Settings saved!");
+                        notificationsService.success("SEO settings saved!");
                     }
                 });
         }

--- a/src/uSeoToolkit.Umbraco.MetaFields.Core/Controllers/MetaFieldsController.cs
+++ b/src/uSeoToolkit.Umbraco.MetaFields.Core/Controllers/MetaFieldsController.cs
@@ -98,7 +98,7 @@ namespace uSeoToolkit.Umbraco.MetaFields.Core.Controllers
             var settings = _documentTypeSettingsService.Get(postModel.ContentTypeId);
             
             if (!_seoSettingsService.IsEnabled(postModel.ContentTypeId))
-                return BadRequest("Seo settings are turned off for this node!");
+                return BadRequest("SEO settings are turned off for this node!");
 
             EnsureLanguage(postModel.Culture);
             var isDirty = false;

--- a/src/uSeoToolkit.Umbraco.MetaFields.Core/Models/SeoService/MetaTagsModel.cs
+++ b/src/uSeoToolkit.Umbraco.MetaFields.Core/Models/SeoService/MetaTagsModel.cs
@@ -26,7 +26,7 @@ namespace uSeoToolkit.Umbraco.MetaFields.Core.Models.SeoService
             var (key, _) = Fields.FirstOrDefault(it => it.Key.Alias.Equals(alias));
             if (key is null)
             {
-                throw new ArgumentException($"No seo field with alias {alias} found!");
+                throw new ArgumentException($"No SEO field with alias {alias} found!");
             }
 
             Fields[key] = value;

--- a/src/uSeoToolkit.Umbraco.MetaFields/App_Plugins/uSeoToolkit/MetaFields/Interface/ContentApps/SeoSettings/seoSettings.html
+++ b/src/uSeoToolkit.Umbraco.MetaFields/App_Plugins/uSeoToolkit/MetaFields/Interface/ContentApps/SeoSettings/seoSettings.html
@@ -19,7 +19,7 @@
         </umb-editor-sub-header-content-right>
     </umb-editor-sub-header>
     <umb-box>
-        <umb-box-header title="Seo Settings"></umb-box-header>
+        <umb-box-header title="SEO settings"></umb-box-header>
         <umb-box-content>
             <div class="umb-property" ng-repeat="field in vm.fields">
                 <div class="control-group umb-control-group">


### PR DESCRIPTION
This goes towards issue #13.
I did an initial sweep of the codebase to correct the capitalising/lowercasing of SEO. There may be more to be corrected? 